### PR TITLE
Use of deprecated PHP4 style class constructor is not supported since…

### DIFF
--- a/recaptcha.php
+++ b/recaptcha.php
@@ -417,17 +417,11 @@ JS;
                echo "
 */
 // *********** FI
-            $com = preg_replace('/([\\/\(\)\+\;\'])',
-               '\'%\' . dechex(ord(\'$1\'))',
-               $comment->comment_content);
-               $com = preg_replace('/\\r\\n/m', '\\\n', $com);
-               echo "
-            <script type='text/javascript'>
-            var _recaptcha_wordpress_savedcomment =  '" . $com  ."';
-            _recaptcha_wordpress_savedcomment =
-                unescape(_recaptcha_wordpress_savedcomment);
-            </script>
-            ";
+            $com = preg_replace_callback(
+                '/([\\/\(\)\+\;\'])',
+                function ($m) {
+                    return '\'%\' . dechex(ord(\'$m[1]\'))';
+                }, $comment->comment_content);
 
             wp_delete_comment($comment->comment_ID);
         }

--- a/recaptcha.php
+++ b/recaptcha.php
@@ -422,6 +422,14 @@ JS;
                 function ($m) {
                     return '\'%\' . dechex(ord(\'$m[1]\'))';
                 }, $comment->comment_content);
+            $com = preg_replace('/\\r\\n/m', '\\\n', $com);
+               echo "
+                <script type='text/javascript'>
+                var _recaptcha_wordpress_savedcomment =  '" . $com  ."';
+                _recaptcha_wordpress_savedcomment =
+                    unescape(_recaptcha_wordpress_savedcomment);
+                </script>
+                ";
 
             wp_delete_comment($comment->comment_ID);
         }

--- a/recaptcha.php
+++ b/recaptcha.php
@@ -406,7 +406,18 @@ JS;
            $comment = get_comment($comment_id);
 
            // todo: removed double quote from list of 'dangerous characters'
-           $com = preg_replace('/([\\/\(\)\+\;\'])/e',
+// XTEC ********** MODIFICAT - Use of deprecated PHP4 style class constructor is not supported since PHP 7.
+// 2017.11.23 @nacho
+// *********** ORIGINAL
+/*
+              $com = preg_replace('/([\\/\(\)\+\;\'])/e',
+               '\'%\' . dechex(ord(\'$1\'))',
+               $comment->comment_content);
+               $com = preg_replace('/\\r\\n/m', '\\\n', $com);
+               echo "
+*/
+// *********** FI
+            $com = preg_replace('/([\\/\(\)\+\;\'])',
                '\'%\' . dechex(ord(\'$1\'))',
                $comment->comment_content);
                $com = preg_replace('/\\r\\n/m', '\\\n', $com);

--- a/recaptchalib.php
+++ b/recaptchalib.php
@@ -52,7 +52,14 @@ class ReCaptcha
      *
      * @param string $secret shared secret between site and ReCAPTCHA server.
      */
-    function ReCaptcha($secret)
+// XTEC ********** MODIFICAT - Use of deprecated PHP4 style class constructor is not supported since PHP 7.
+// *********** ORIGINAL
+// 2017.11.23 @nacho
+/*
+	function ReCaptcha($secret)
+*/
+// *********** FI
+    function __construct($secret)
     {
         if ($secret == null || $secret == "") {
             die("To use reCAPTCHA you must get an API key from <a href='"


### PR DESCRIPTION
Use of deprecated PHP4 style class constructor is not supported since PHP 7.
preg_replace() - /e modifier is deprecated since PHP 5.5 and removed since PHP 7.0